### PR TITLE
Store impersonated id in session rather than full user object

### DIFF
--- a/src/ZfcUserImpersonate/Service/User.php
+++ b/src/ZfcUserImpersonate/Service/User.php
@@ -57,7 +57,7 @@ class User extends ZfcUserUserService
 
         // Start impersonation by overwriting the identity stored in auth storage. Essentially, this sets the user to
         // impersonate as the logged-in user.
-        $this->getAuthService()->getStorage()->write($userToImpersonate);
+        $this->getAuthService()->getStorage()->write($userToImpersonate->getId());
     }
 
     /**


### PR DESCRIPTION
When using Doctrine ORM and a user entity with associated entities, serializing the user into the session causes some problems. The associations are not properly initialized when the user is unserialized in subsequent requests. This commit switches to just storing the user id rather than the whole object, which allows zfcuser's Storage/Db.php::read() to pull the user entity from the mapper, including properly set up association proxies.
